### PR TITLE
fix: update pagination to display 15 items per page in ProgrammerCont…

### DIFF
--- a/app/Http/Controllers/ProgrammerController.php
+++ b/app/Http/Controllers/ProgrammerController.php
@@ -20,7 +20,7 @@ class ProgrammerController extends Controller
             })
             ->orderByDesc('max_cf_rating')
             ->orderBy('name')
-            ->paginate(12) // 12 items per page (4 rows × 3 items)
+            ->paginate(15) // 15 items per page (5 rows × 3 items)
             ->through(function ($user) {
                 return [
                     'id' => $user->id,


### PR DESCRIPTION
This pull request makes a minor update to the pagination settings in the `ProgrammerController`. The number of items displayed per page has been increased to show more results at once.

- Pagination update:
  * Changed the number of items per page in the `index` method from 12 to 15 to display 5 rows of 3 items each instead of 4 rows. (`app/Http/Controllers/ProgrammerController.php`)